### PR TITLE
Change ngInit to AfterViewInit

### DIFF
--- a/src/app/home2/home2.page.ts
+++ b/src/app/home2/home2.page.ts
@@ -7,14 +7,14 @@ import {HidenavStretchheaderComponent} from '../hidenav/hidenav-stretchheader.co
   templateUrl: './home2.page.html',
   styleUrls: ['./home2.page.scss'],
 })
-export class Home2Page implements OnInit {
+export class Home2Page implements AfterViewInit {
 
   @ViewChild(IonContent) content: IonContent;
   @ViewChild('title', {read: ElementRef}) title: ElementRef;
   @ViewChild(HidenavStretchheaderComponent) hidenav: HidenavStretchheaderComponent;
   constructor() { }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.hidenav.scroll.subscribe(res => {
       this.title.nativeElement.style.transform = 'translate3d(0, '+(res-50)+'px, 0)';
     })


### PR DESCRIPTION
You should wait the view load to subscribe elements. If you do in ngInit your element will return undefined. i guess you should need change in all screens, components or pages wich subscribe your hidenav. 

Sorry, but i dont open pr the right way because i don't compiled and dont download this project, but when i copied this code just worked when use ngAfterViewInit.